### PR TITLE
chat-spaceの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Things you may want to cover:
 * Configuration
 
 * Database creation
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
 
 * Database initialization
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 |------|----|-------|
 |id|integer|null: false|
 |name|string|null: false|
-|email|string|null: false, unique: true
+|email|string|null: false, unique: true|
 |password|string|null: false, unique: true|
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 ### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users
+- has_many :messages
 
 
 ## messagesテーブル
@@ -41,8 +42,10 @@
 |------|----|-------|
 |id|integer|null: false|
 |user-id|integer|null: false, foreign_key: true|
+|image|string|
 |comment|text|null: false|
 |created-at|string|null: false|
 
 ### Association
 - belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Association
 - belongs_to :group
-- belongs_to :user
+- belongs_to :user 
 
 
 ## usersテーブル

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@
 |Column|Type|Options|
 |------|----|-------|
 |id|integer|null: false|
+
+### Association
+- has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 |------|----|-------|
 |id|integer|null: false|
 |user-id|integer|null: false, foreign_key: true|
-|text|text|null: false|
+|comment|text|null: false|
 |created-at|string|null: false|
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -1,17 +1,4 @@
-# README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
 ## groups_usersテーブル
 
 |Column|Type|Options|
@@ -23,12 +10,20 @@ Things you may want to cover:
 - belongs_to :group
 - belongs_to :user
 
-* Database initialization
 
-* How to run the test suite
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|id|integer|null: false|
+|nickname|string|null: false|
+|email|string|null: false, unique: true|
+|password|string|null: false, unique: true|
 
-* Services (job queues, cache servers, search engines, etc.)
+### Association
+- has_many :groups_users
 
-* Deployment instructions
 
-* ...
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|id|integer|null: false|

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|id|integer|null: false|
 |user-id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false,foreign_key: true|
 |image|string|
-|comment|text|null: false|
+|comment|text|
 |created-at|string|null: false|
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |id|integer|null: false|
-|member|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 |------|----|-------|
 |id|integer|null: false|
 |name|string|null: false|
-|email|string|null: false, unique: true|
+|email|string|null: false, unique: true
 |password|string|null: false, unique: true|
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user-id|integer|null: false, foreign_key: true|
+|id|integer|null: false|
+|user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false,foreign_key: true|
 |image|string|
 |comment|text|

--- a/README.md
+++ b/README.md
@@ -15,18 +15,34 @@
 |Column|Type|Options|
 |------|----|-------|
 |id|integer|null: false|
-|nickname|string|null: false|
+|name|string|null: false|
 |email|string|null: false, unique: true|
 |password|string|null: false, unique: true|
 
 ### Association
 - has_many :groups_users
+- has_many :gruops, through: :groups_users
+- has_many :messages
 
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |id|integer|null: false|
+|member|string|null: false|
 
 ### Association
 - has_many :groups_users
+- has_many :users, through: :groups_users
+
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|id|integer|null: false|
+|user-id|integer|null: false, foreign_key: true|
+|text|text|null: false|
+|created-at|string|null: false|
+
+### Association
+- belongs_to :user


### PR DESCRIPTION
# what 
chat-spaceを実装する。
readme.mdファイルにテーブル名、アソシエーションを追加。

# why
readmeファイルに記述し、リモートリポジトリに反映させるため。